### PR TITLE
Fix Build and use Scala 2.11 code

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -48,7 +48,8 @@ object castor extends Module {
   class ActorJsModule(crossScalaVersion: String, crossScalaJsVersion: String) extends ActorModule(crossScalaVersion) with ScalaJSModule {
     def platformSegment = "js"
     def scalaJSVersion = crossScalaJsVersion
-    object test extends ActorTestModule {
+    def millSourcePath = super.millSourcePath / os.up
+    object test extends Tests with ActorTestModule {
       def platformSegment = "js"
       def scalaVersion = crossScalaVersion
     }
@@ -67,7 +68,7 @@ object castor extends Module {
   class ActorNativeModule(crossScalaVersion: String, crossScalaNativeVersion: String) extends ActorModule(crossScalaVersion) with ScalaNativeModule {
     def platformSegment = "native"
     def scalaNativeVersion = crossScalaNativeVersion
-
+    def millSourcePath = super.millSourcePath / os.up
     object test extends Tests with ActorTestModule {
       def platformSegment = "native"
     }

--- a/castor/src/Actors.scala
+++ b/castor/src/Actors.scala
@@ -13,7 +13,11 @@ abstract class BaseActor[T]()(implicit ac: Context) extends Actor[T]{
     queue.enqueue((t, token))
     if (!scheduled){
       scheduled = true
-      ac.execute(() => runWithItems())
+      ac.execute(
+        new Runnable{
+          def run(): Unit = runWithItems()
+        }
+      )
     }
   }
   def sendAsync(f: scala.concurrent.Future[T])
@@ -32,7 +36,11 @@ abstract class BaseActor[T]()(implicit ac: Context) extends Actor[T]{
     runBatch0(msgs)
 
     synchronized{
-      if (queue.nonEmpty) ac.execute(() => runWithItems())
+      if (queue.nonEmpty) ac.execute(
+        new Runnable{
+          def run(): Unit = runWithItems()
+        }
+      )
       else{
         assert(scheduled)
         scheduled = false

--- a/castor/src/Context.scala
+++ b/castor/src/Context.scala
@@ -167,9 +167,11 @@ object Context{
                        line: sourcecode.Line) = {
       val token = reportSchedule(a, msg, fileName, line)
       scheduler.schedule[Unit](
-        () => {
-          a.send(msg)(fileName, line)
-          reportComplete(token)
+        new java.util.concurrent.Callable[Unit] {
+          def call(): Unit = {
+            a.send(msg)(fileName, line)
+            reportComplete(token)
+          }
         },
         delay.toMillis,
         TimeUnit.MILLISECONDS


### PR DESCRIPTION
With last PR I broke the castor build.
I don't know if it's ok for you to have anonymous classes instead of functions (Scala 2.11 compatibility) in the shared code.
Fortunately the Scala JS version was already published, otherwise it would have had nothing inside!